### PR TITLE
Run build in Github actions

### DIFF
--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -4,7 +4,6 @@ on: workflow_dispatch
     
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
@@ -16,5 +15,5 @@ jobs:
         host: 'linux'
         target: 'desktop'
         arch: 'gcc_64'
-    - name: Test tool paths
-      run: qmake
+    - name: Run build
+      run: ./build.sh --compress

--- a/build.bat
+++ b/build.bat
@@ -1,22 +1,8 @@
 @echo off
 
-REM Parse user inputs for tool paths.
-set "qtPath=C:\Qt"
-if not "%1"=="" (
-    if not "%1"=="--compress" (
-        set "qtPath=%1"
-    )
-)
-if not "%2"=="" (
-    if not "%2"=="--compress" (
-        set "qtPath=%2"
-    )
-)
-
 REM Parse user inputs for command line arguments.
 set "compress=false"
 if "%1"=="--compress" set "compress=true"
-if "%2"=="--compress" set "compress=true"
 
 REM Initialize bin directory, if not existing.
 echo Generating bin directory...
@@ -25,14 +11,14 @@ cd bin
 
 REM Clean and run qmake/make build steps.
 echo Building new exe...
-"%qtPath%\Tools\mingw1120_64\bin\mingw32-make.exe" clean
-"%qtPath%\6.5.3\mingw_64\bin\qmake.exe" ../project/TotkArmorTracker.pro -spec win32-g++ "CONFIG+=qtquickcompiler"
-"%qtPath%\Tools\mingw1120_64\bin\mingw32-make.exe" -f Makefile qmake_all
-"%qtPath%\Tools\mingw1120_64\bin\mingw32-make.exe"
+mingw32-make clean
+qmake ../project/TotkArmorTracker.pro -spec win32-g++ "CONFIG+=qtquickcompiler"
+mingw32-make -f Makefile qmake_all
+mingw32-make
 
 REM Run windeployqt to give the generated exe all required dll's.
 copy *.xml release
-windeployqt.exe ./release/TotkArmorTracker.exe --qmldir ../project
+windeployqt ./release/TotkArmorTracker.exe --qmldir ../project
 
 REM (OPTIONAL) Compress the final project using 7zip and move to the parent directory.
 if "%compress%"=="true" (

--- a/build.sh
+++ b/build.sh
@@ -7,9 +7,9 @@ cd bin
 
 # Clean and run qmake/make build steps.
 echo Building new exe...
-"/usr/bin/make" clean -j4
-"/opt/Qt/6.5.2/gcc_64/bin/qmake" ../project/TotkArmorTracker.pro -spec linux-g++ CONFIG+=qtquickcompiler
-"/usr/bin/make" -j4
+make clean -j4
+qmake ../project/TotkArmorTracker.pro -spec linux-g++ CONFIG+=qtquickcompiler
+make -j4
 
 # If flags are raised to compress outputs, tar all generated files.
 if [ "$1" = "--compress" ]


### PR DESCRIPTION
- Removed full tool paths from build scripts - expects tools to be available in user's env
- Set release build to build exes and compress